### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-####JVM options for smoother Android Studio experience
+#### JVM options for smoother Android Studio experience
 
-######Tired of slow Android Studio? 
+###### Tired of slow Android Studio? 
 Yeah, me too.
 
 Here are some `vmoptions` I use for Android Studio, it starts **faster** and runs **smoother** than on default options.
@@ -10,7 +10,7 @@ You will find all installation instuctions in the [studio.vmoptions file](studio
 -----------
 JVM Options target HotSpot JRE 8, all of them are compatible with Mac OS, Linux and Windows.
 
-#####Download
+##### Download
 See [studio.vmoptions file](studio.vmoptions).
 
 ------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
